### PR TITLE
gitignoreにconfig.jsonを追記しました

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,6 @@ dist/
 *.egg-info
 
 # Secret
-/pybf/config.json
+config.json
 
 files.txt

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,7 @@ build/
 dist/
 *.egg-info
 
+# Secret
+/pybf/config.json
+
 files.txt


### PR DESCRIPTION
#11 

privateAPIを利用する時に、APIKey,APISecretをconfig.jsonに記述する必要があると思うので、
もしもの時のために、.gitignoreにconfig.jsonを追記してみました。

いかがでしょうかー？